### PR TITLE
Bugfix/sync issue for discarded drives

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "capybara"
   gem "capybara-screenshot"
-  gem 'capybara-selenium'
   gem "factory_bot_rails"
   gem "pundit-matchers", "~> 1.6.0"
   gem "rails-controller-testing"
@@ -95,7 +94,7 @@ group :development, :test do
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rails"
-  gem 'webdrivers', "~> 3"
+  gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov"
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
     ast (2.4.2)
     audited (4.10.0)
@@ -78,6 +78,7 @@ GEM
       faraday_middleware (~> 1.0, >= 1.0.0.rc1)
       net-http-persistent (~> 4.0)
       nokogiri (~> 1, >= 1.10.8)
+    base64 (0.2.0)
     bcrypt (3.1.18)
     benchmark-malloc (0.2.0)
     benchmark-perf (0.6.0)
@@ -96,11 +97,11 @@ GEM
     brakeman (5.2.3)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.37.1)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
@@ -108,9 +109,6 @@ GEM
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
-    capybara-selenium (0.0.6)
-      capybara
-      selenium-webdriver
     caxlsx (3.2.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
@@ -119,7 +117,6 @@ GEM
     caxlsx_rails (0.6.3)
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
-    childprocess (3.0.0)
     cocoon (1.2.15)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -221,6 +218,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    logger (1.6.5)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -230,8 +228,8 @@ GEM
     matrix (0.4.2)
     memoist (0.16.2)
     method_source (1.0.0)
-    mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.16.3)
     monetize (1.9.4)
       money (~> 6.12)
@@ -267,8 +265,8 @@ GEM
       timeout
     newrelic_rpm (8.8.0)
     nio4r (2.5.8)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.18.1)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
@@ -276,18 +274,18 @@ GEM
       ast (~> 2.4.1)
     pg (1.4.1)
     popper_js (1.16.0)
-    public_suffix (4.0.7)
+    public_suffix (6.0.1)
     puma (5.6.4)
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)
     pundit-matchers (1.6.0)
       rspec-rails (>= 3.0.0)
-    racc (1.6.1)
-    rack (2.2.4)
+    racc (1.8.1)
+    rack (2.2.10)
     rack-protection (2.2.0)
       rack
-    rack-test (2.0.2)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rails (6.1.6)
       actioncable (= 6.1.6)
@@ -330,7 +328,7 @@ GEM
     redis (4.7.1)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
-    regexp_parser (2.5.0)
+    regexp_parser (2.10.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -340,7 +338,7 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rexml (3.2.5)
+    rexml (3.4.0)
     rgeo (2.4.0)
     rgeo-geojson (2.1.1)
       rgeo (>= 1.0.0)
@@ -393,7 +391,7 @@ GEM
       rubocop (>= 0.90.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    rubyzip (1.3.0)
+    rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -406,9 +404,12 @@ GEM
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
     select2-rails (4.0.13)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.27.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     simple_calendar (2.4.3)
@@ -461,10 +462,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (3.9.4)
-      nokogiri (~> 1.6)
-      rubyzip (~> 1.0)
-      selenium-webdriver (~> 3.0)
+    websocket (1.2.11)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -486,7 +484,6 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
-  capybara-selenium
   caxlsx (~> 3.1)
   caxlsx_rails
   cocoon
@@ -530,6 +527,7 @@ DEPENDENCIES
   sassc-rails (~> 2.1)
   scenic (~> 1.5)
   select2-rails
+  selenium-webdriver
   shoulda-matchers
   simple_calendar (~> 2.0)
   simplecov
@@ -540,7 +538,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  webdrivers (~> 3)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/api/v1/drives_controller.rb
+++ b/app/controllers/api/v1/drives_controller.rb
@@ -57,6 +57,9 @@ class Api::V1::DrivesController < Api::V1::ApiController
     authorize @record
     if @record.save
       render :create, status: :created
+    elsif @record.discarded?
+      # This is a workaround to prevent invalid discarded drives from constantly being re uploaded
+      render :create, status: :ok
     else
       render json: { error: @record.errors }, status: :bad_request
     end

--- a/app/controllers/api/v1/drives_controller.rb
+++ b/app/controllers/api/v1/drives_controller.rb
@@ -59,7 +59,7 @@ class Api::V1::DrivesController < Api::V1::ApiController
       render :create, status: :created
     elsif @record.discarded?
       # This is a workaround to prevent invalid discarded drives from constantly being re uploaded
-      render :create, status: :ok
+      render :create, status: :created
     else
       render json: { error: @record.errors }, status: :bad_request
     end

--- a/app/models/drive.rb
+++ b/app/models/drive.rb
@@ -21,7 +21,11 @@ class Drive < ApplicationRecord
   belongs_to :customer, optional: true
   belongs_to :site, optional: true
 
-  validates :end, date: { after: :start }
+  validates :end, presence: true
+  validates :start, presence: true
+  validates :end, date: true
+  validates :start, date: true
+  validate :end_after_start
   validate :vehicle_same_as_tour
 
   # Allow to discard instead of destroy drives
@@ -216,6 +220,13 @@ COALESCE(SUM(distance_km), cast('0' as double precision)) as distance")[0]
   end
 
   private
+
+    def end_after_start
+      if self.end && self.start && self.start >= self.end
+        errors.add(:end, :date_after)
+      end
+    end
+
     def vehicle_same_as_tour
       if tour&.vehicle && vehicle != tour.vehicle
         errors.add(:vehicle, :vehicle_not_sames_as_tour)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -724,7 +724,7 @@ CREATE MATERIALIZED VIEW public.drives_with_pricings AS
  SELECT DISTINCT drive_grouped.tour_id,
     drive_grouped.customer_id,
     s.display_name AS site_name,
-    timezone('CET'::text, timezone('utc'::text, drive_grouped.start)) AS start,
+    timezone('Europe/Zurich'::text, timezone('utc'::text, drive_grouped.start)) AS start,
     drive_grouped.vehicle_id,
     v.name AS vehicle,
     a.name AS activity,
@@ -818,7 +818,7 @@ CREATE MATERIALIZED VIEW public.drives_with_pricings AS
           ORDER BY pricing_flat_rates.valid_from DESC
          LIMIT 1))))
   WHERE (t.discarded_at IS NULL)
-  ORDER BY (timezone('CET'::text, timezone('utc'::text, drive_grouped.start))) DESC
+  ORDER BY (timezone('Europe/Zurich'::text, timezone('utc'::text, drive_grouped.start))) DESC
   WITH NO DATA;
 
 
@@ -3133,6 +3133,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230125230025'),
 ('20230327150059'),
 ('20231223111451'),
-('20240102232703');
+('20240102232703'),
+('20240102234431');
 
 

--- a/spec/controllers/api/v1/drives_controller_spec.rb
+++ b/spec/controllers/api/v1/drives_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Api::V1::DrivesController, type: :controller do
     describe "response code" do
       subject { response }
 
-      its(:code) { is_expected.to eq "200" }
+      its(:code) { is_expected.to eq "201" }
     end
   end
 

--- a/spec/controllers/api/v1/drives_controller_spec.rb
+++ b/spec/controllers/api/v1/drives_controller_spec.rb
@@ -122,6 +122,34 @@ RSpec.describe Api::V1::DrivesController, type: :controller do
     end
   end
 
+  describe "post discarded" do
+    let(:vehicle) { create(:vehicle, company: driver.company) }
+    let(:tour) { create(:tour, driver: driver, vehicle: vehicle) }
+    let(:minimal_params) { { start: 1.hour.ago, end: 1.minute.ago, created_at: Time.current, tour_id: tour.id, discarded_at: Time.current } }
+
+    before { post :create, params: { driver_id: driver.to_param, format: :json }.merge(minimal_params) }
+
+    describe "response code" do
+      subject { response }
+
+      its(:code) { is_expected.to eq "201" }
+    end
+  end
+
+  describe "post discarded invalid drive" do
+    let(:vehicle) { create(:vehicle, company: driver.company) }
+    let(:tour) { create(:tour, driver: driver, vehicle: vehicle) }
+    let(:minimal_params) { { start: 1.hour.ago, end: 1.hour.ago, created_at: Time.current, tour_id: tour.id, discarded_at: Time.current } }
+
+    before { post :create, params: { driver_id: driver.to_param, format: :json }.merge(minimal_params) }
+
+    describe "response code" do
+      subject { response }
+
+      its(:code) { is_expected.to eq "200" }
+    end
+  end
+
   describe "put" do
     let(:tour) { create(:tour, driver: driver) }
     let!(:existing_drive) { create(:drive, start: 1.hour.ago, end: 1.minute.ago, driver: driver, tour_id: tour.id ) }

--- a/spec/models/drive_spec.rb
+++ b/spec/models/drive_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe Drive, type: :model do
       subject.end = 2.hours.ago
       expect(subject).not_to be_valid
     end
+
+    it "should be valid when end time is 1ms after start" do
+      subject.end = subject.start + 0.001.seconds
+      expect(subject).to be_valid
+    end
+
+    it "should not be valid when end time is equal to start" do
+      subject.end = subject.start
+      expect(subject).not_to be_valid
+    end
   end
 
   describe "#company" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,23 +34,15 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
-end
+# Capybara.register_driver :headless_chrome do |app|
+#   opts = Selenium::WebDriver::Chrome::Options.new
+#   chrome_args = %w[--headless --no-sandbox --disable-gpu --window-size=1920,1080 --remote-debugging-port=9222]
+#   chrome_args.each { |arg| opts.add_argument(arg) }
+#
+#   Capybara::Selenium::Driver.new app,browser: :chrome, options: opts
+# end
 
-Capybara.register_driver :headless_chrome do |app|
-  caps = Selenium::WebDriver::Remote::Capabilities.chrome(loggingPrefs: { browser: 'ALL' })
-  opts = Selenium::WebDriver::Chrome::Options.new
-  chrome_args = %w[--headless --no-sandbox --disable-gpu --window-size=1920,1080 --remote-debugging-port=9222]
-  chrome_args.each { |arg| opts.add_argument(arg) }
-
-  Capybara::Selenium::Driver.new app,
-                                 browser: :chrome,
-                                 options: opts,
-                                 desired_capabilities: caps
-end
-
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :selenium_chrome_headless
 
 RSpec.configure do |config|
   # Allows us to mock times
@@ -89,7 +81,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :headless_chrome
+    driven_by :selenium_chrome_headless
   end
 
   config.include SystemScenarios, type: :system


### PR DESCRIPTION
- Return success on invalid drives if they are marked as discarded to prevent infinite retries.
- Validate end time after start time with milliseconds resolution to prevent invalid drive for very short drives